### PR TITLE
Add option to apply CSS styles to the content node elment

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,16 @@ document.getElementById('btn1').addEventListener("click", function(){
 superClipBoard.bind(document.getElementById('btn2'), option);
 ```
 
+### Tips and tricks
+In cases where your content is styled with CSS the style will be copied to your clipboard. This can be an issue when you paste in places like Word documents or Google spreadsheets. To avoid this add the following style to your stylesheet.
+```
+pre.superClipBoardContentNode {
+    all: initial;
+    * {
+    all: unset;
+    }
+}
+```
+
 # License
 [MIT License](https://raw.githubusercontent.com/milan-hwj/SuperClipBoard/master/LICENSE)

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ class ClipBoard {
      * @return   dom
      */
     const copyDom = document.createElement('pre');
+    copyDom.setAttribute('class', 'superClipBoardContentNode');
     copyDom.style.position = 'absolute';
     copyDom.style.left = '-9999px';
     copyDom.style.top = '-9999px';


### PR DESCRIPTION
Add a CSS class, `.superClipBoardContentNode` to the content node in order to style it with CSS.
This fixes an issue where a white link (on the website) pasted into a google document with a white background would "disappear" (white on white).
